### PR TITLE
new focus handling

### DIFF
--- a/frontend/src/components/Desktop/Window/Window.jsx
+++ b/frontend/src/components/Desktop/Window/Window.jsx
@@ -303,6 +303,9 @@ export default class Window extends Component {
 
     // TODO: display: none
 
+    // notify AppRuntime to pass focus
+    this.props.app.onMinimize();
+
     $(this._el).addClass(CSS_CLASS_NAME_HIDE);
 
     // this.lifecycleEvents.broadcast(EVT_WINDOW_DID_HIDE);
@@ -342,10 +345,8 @@ export default class Window extends Component {
   }
 
   async restore() {
-    console.log('restore')
     // this.lifecycleEvents.broadcast(EVT_WINDOW_WILL_MINIMIZE);
     if(this._isMinimized) {
-      console.log('restore2')
       await this.unhide();
       await this.animate(EFFECT_RESTORE);
       this._isMinimized = false;

--- a/frontend/src/core/AppRegistration.js
+++ b/frontend/src/core/AppRegistration.js
@@ -1,11 +1,18 @@
 import EventEmitter from 'events';
 import AppRuntime from './AppRuntime';
 import AppRegistryLinkedState from 'state/AppRegistryLinkedState';
+import DesktopLinkedState from 'state/DesktopLinkedState';
 import { EVT_EXIT /*, EVT_WINDOW_RESIZE*/} from 'process/ClientProcess';
 import './AppRuntime.typedef';
 
+const commonDesktopLinkedState = new DesktopLinkedState();
 const commonAppRegistryLinkedState = new AppRegistryLinkedState();
 let _createdWindowsCount = 0;
+
+
+
+
+
 
 /**
  * Creates a registration which automatically populates app menus and the Dock
@@ -155,7 +162,9 @@ class AppRegistration extends EventEmitter {
   }
 
   focus() {
-    this._appRuntime.forEach(a=> a.focus());
+    //focus respecting order
+    const apps = commonDesktopLinkedState.getAppRuntimeFocusOrder().filter(a => (this._appRuntime.indexOf(a)>-1))
+    apps.forEach(a=> a.focus());
   }
 
   getIconSrc() {

--- a/frontend/src/core/AppRuntime.js
+++ b/frontend/src/core/AppRuntime.js
@@ -6,9 +6,6 @@ import './AppRuntime.typedef';
 
 const commonDesktopLinkedState = new DesktopLinkedState();
 
-// TODO: Handle via DesktopLinkedState
-let _focusedAppRuntime = null;
-
 // export const EVT_CONTENT_UPDATE = 'content-update';
 // export const EVT_TITLE_UPDATE = 'title-update';
 // export const EVT_ICON_SRC_UPDATE = 'icon-src-update';
@@ -40,6 +37,7 @@ class AppRuntime extends ClientGUIProcess {
     this._mainView = null;
     this._appCmd = null;
     this._isFocused = false;
+    this._isMinimized = false;
     //TODO: do get set?
     this.menuItems = runProps.menuItems;
 
@@ -102,19 +100,24 @@ class AppRuntime extends ClientGUIProcess {
       });
 
       this.on(EVT_FOCUS, () => {
+        const focusedAppRuntime = commonDesktopLinkedState.getFocusedAppRuntime();
+        console.log('received focus for', this._title, 'last focused was', focusedAppRuntime?focusedAppRuntime._title:'null')
         // Ignore if already focused
-        if (Object.is(this, _focusedAppRuntime)) {
+        /*if (Object.is(this, focusedAppRuntime)) {
           return;
-        }
+        }*/
   
         // Blur existing GUI process, if present
-        if (_focusedAppRuntime) {
-          _focusedAppRuntime.blur();
-        }
+        /*if (focusedAppRuntime) {
+          focusedAppRuntime.blur();
+        }*/
   
-        _focusedAppRuntime = this;
-        commonDesktopLinkedState.setFocusedAppRuntme(this);
+        commonDesktopLinkedState.setFocusedAppRuntime(this);
       });
+
+      this.on(EVT_BLUR, () => {
+        
+      })
 
       // Register w/ DesktopLinkedState
       // Note (as of the time of writing) the underlying ClientProcess also
@@ -123,12 +126,18 @@ class AppRuntime extends ClientGUIProcess {
       commonDesktopLinkedState.addLaunchedAppRuntime(this);
 
       this.once(EVT_BEFORE_EXIT, () => {
-        if (Object.is(this, _focusedAppRuntime)) {
-          // TODO: Handle via DesktopLinkedState
-          _focusedAppRuntime = null;
-          commonDesktopLinkedState.setFocusedAppRuntme(null);
-        }
+        const focusedAppRuntime = commonDesktopLinkedState.getFocusedAppRuntime();
+        if (Object.is(this, focusedAppRuntime)) {
 
+          const appRuntimeFocusOrder = commonDesktopLinkedState.getAppRuntimeFocusOrder();
+          if(appRuntimeFocusOrder.length > 1) {
+            // pass focus to latest focused window
+            appRuntimeFocusOrder[appRuntimeFocusOrder.length - 2].focus();
+          } else {
+            commonDesktopLinkedState.setFocusedAppRuntime(null);
+          }
+        }
+        
         // Unregister from DesktopLinkedState
         commonDesktopLinkedState.removeLaunchedAppRuntime(this);
       });
@@ -143,6 +152,11 @@ class AppRuntime extends ClientGUIProcess {
     } catch (exc) {
       throw exc;
     }
+  }
+
+  onMinimize() {
+    this._isMinimized = true;
+    commonDesktopLinkedState.setMinimizedAppRuntime(this);
   }
 
   onResizeMove(position, size) {
@@ -199,6 +213,7 @@ class AppRuntime extends ClientGUIProcess {
    * Utilizes this.setIsFocused().
    */
   focus() {
+    this._isMinimized = false;
     this.setIsFocused(true);
   }
 
@@ -225,14 +240,14 @@ class AppRuntime extends ClientGUIProcess {
    * @param {boolean} isFocused 
    */
   setIsFocused(isFocused) {
+    // TODO: Remove
+    console.debug(`${isFocused ? 'Focusing' : 'Blurring'} app runtime`, this._title, this);
+
     // Ignore duplicate
     if (this._isFocused === isFocused) {
       console.warn('isFocused is already set to:', isFocused);
       return;
     }
-
-    // TODO: Remove
-    console.debug(`${isFocused ? 'Focusing' : 'Blurring'} app runtime`, this);
 
     this.setImmediate(() => {
       this._isFocused = isFocused;


### PR DESCRIPTION
have used the desktoplinkedstate to manage windows focus & order, now when you focus multiple instances the order of focus is preserved, also when you close or minimise a window the focus is passed to the previous one in the stack